### PR TITLE
[FE] 한국어 자연어 → JSON 파싱 함수 구현 (#5)

### DIFF
--- a/ai-synthor/app/services/kor_to_eng_field_map.py
+++ b/ai-synthor/app/services/kor_to_eng_field_map.py
@@ -1,0 +1,210 @@
+KOR_TO_ENG_FIELD = {
+    # korean_full_name
+    "전체 이름": "korean_full_name",
+    "이름 전체": "korean_full_name",
+    "성명": "korean_full_name",
+    "풀네임": "korean_full_name",
+    "전성 이름": "korean_full_name",
+    "이름": "korean_full_name",
+    "이름 전체": "korean_full_name",
+    "이름 전부": "korean_full_name",
+    "이름 풀": "korean_full_name",
+    "이름(전체)": "korean_full_name",
+    "이름(풀)": "korean_full_name",
+    "이름 전체명": "korean_full_name",
+    "이름 풀네임": "korean_full_name",
+    # korean_last_name
+    "성": "korean_last_name",
+    "성씨": "korean_last_name",
+    "이씨": "korean_last_name",
+    "김씨": "korean_last_name",
+    "박씨": "korean_last_name",
+    "최씨": "korean_last_name",
+    "이 성": "korean_last_name",
+    "김 성": "korean_last_name",
+    "박 성": "korean_last_name",
+    "최 성": "korean_last_name",
+    "성(이)": "korean_last_name",
+    "성(김)": "korean_last_name",
+    "성(박)": "korean_last_name",
+    "성(최)": "korean_last_name",
+    # korean_first_name
+    "이름(이)": "korean_first_name",
+    "이름(김)": "korean_first_name",
+    "이름(박)": "korean_first_name",
+    "이름(최)": "korean_first_name",
+    "이름만": "korean_first_name",
+    "이름(한글)": "korean_first_name",
+    "이름(영문)": "korean_first_name",
+    # korean_address
+    "주소": "korean_address",
+    "전체 주소": "korean_address",
+    "집 주소": "korean_address",
+    "거주지": "korean_address",
+    "거주 주소": "korean_address",
+    "거주지 주소": "korean_address",
+    "거주지 전체": "korean_address",
+    # korean_street_address
+    "도로명 주소": "korean_street_address",
+    "도로 주소": "korean_street_address",
+    "도로명": "korean_street_address",
+    "도로 전체": "korean_street_address",
+    "도로명 전체": "korean_street_address",
+    "도로명주소": "korean_street_address",
+    # korean_city
+    "도시": "korean_city",
+    "도시 이름": "korean_city",
+    "사는 도시": "korean_city",
+    "거주 도시": "korean_city",
+    "시": "korean_city",
+    "시 이름": "korean_city",
+    "도시 이름(한글)": "korean_city",
+    # korean_state
+    "시도": "korean_state",
+    "도": "korean_state",
+    "시/도": "korean_state",
+    "시 도": "korean_state",
+    "도 이름": "korean_state",
+    "시 이름": "korean_state",
+    # korean_country
+    "국가": "korean_country",
+    "나라": "korean_country",
+    "거주 국가": "korean_country",
+    "사는 나라": "korean_country",
+    # korean_postal_code
+    "우편번호": "korean_postal_code",
+    "우편 코드": "korean_postal_code",
+    "우편 번호": "korean_postal_code",
+    "우편코드": "korean_postal_code",
+    # korean_phone
+    "전화번호": "korean_phone",
+    "휴대폰 번호": "korean_phone",
+    "핸드폰 번호": "korean_phone",
+    "연락처": "korean_phone",
+    "휴대폰": "korean_phone",
+    "핸드폰": "korean_phone",
+    "전화": "korean_phone",
+    # korean_company_name
+    "회사명": "korean_company_name",
+    "회사 이름": "korean_company_name",
+    "근무처": "korean_company_name",
+    "근무 회사": "korean_company_name",
+    # korean_job_title
+    "직책": "korean_job_title",
+    "직위": "korean_job_title",
+    "포지션": "korean_job_title",
+    "직무": "korean_job_title",
+    # korean_department_corporate
+    "부서": "korean_department_corporate",
+    "소속": "korean_department_corporate",
+    "소속 부서": "korean_department_corporate",
+    "소속팀": "korean_department_corporate",
+    # korean_product_name
+    "제품명": "korean_product_name",
+    "상품명": "korean_product_name",
+    "제품 이름": "korean_product_name",
+    "상품 이름": "korean_product_name",
+    # korean_product_category
+    "제품 카테고리": "korean_product_category",
+    "상품 카테고리": "korean_product_category",
+    "제품 종류": "korean_product_category",
+    "상품 종류": "korean_product_category",
+    # korean_catch_phrase
+    "캐치프레이즈": "korean_catch_phrase",
+    "슬로건": "korean_catch_phrase",
+    "표어": "korean_catch_phrase",
+    # korean_product_description
+    "제품 설명": "korean_product_description",
+    "상품 설명": "korean_product_description",
+    "제품 소개": "korean_product_description",
+    "상품 소개": "korean_product_description",
+    # korean_language
+    "언어": "korean_language",
+    "사용 언어": "korean_language",
+    "쓰는 언어": "korean_language",
+    # korean_color
+    "색상": "korean_color",
+    "컬러": "korean_color",
+    "색": "korean_color",
+    # username
+    "사용자명": "username",
+    "유저명": "username",
+    "계정명": "username",
+    "계정 이름": "username",
+    "유저 이름": "username",
+    # password
+    "비밀번호": "password",
+    "패스워드": "password",
+    "비번": "password",
+    # email_address
+    "이메일": "email_address",
+    "이메일 주소": "email_address",
+    "메일": "email_address",
+    "메일 주소": "email_address",
+    # domain_name
+    "도메인": "domain_name",
+    "도메인 이름": "domain_name",
+    # url
+    "URL": "url",
+    "주소(URL)": "url",
+    "링크": "url",
+    "웹주소": "url",
+    # mac_address
+    "MAC 주소": "mac_address",
+    # ip_v4_address
+    "IPv4 주소": "ip_v4_address",
+    # ip_v6_address
+    "IPv6 주소": "ip_v6_address",
+    # user_agent
+    "유저 에이전트": "user_agent",
+    # avatar
+    "아바타": "avatar",
+    "프로필 사진": "avatar",
+    "프로필 이미지": "avatar",
+    # app_name
+    "앱 이름": "app_name",
+    "어플 이름": "app_name",
+    # app_version
+    "버전": "app_version",
+    "앱 버전": "app_version",
+    # device_model
+    "기기 모델": "device_model",
+    # device_brand
+    "기기 브랜드": "device_brand",
+    # device_os
+    "OS": "device_os",
+    "운영체제": "device_os",
+    # credit_card_number
+    "카드번호": "credit_card_number",
+    "신용카드 번호": "credit_card_number",
+    # credit_card_type
+    "카드 종류": "credit_card_type",
+    "카드 타입": "credit_card_type",
+    "VISA MASTER 종류": "credit_card_type",
+    # currency
+    "통화": "currency",
+    "화폐 단위": "currency",
+    # iban
+    "IBAN": "iban",
+    "IBAN 코드": "iban",
+    # swift_bic
+    "SWIFT": "swift_bic",
+    "SWIFT 코드": "swift_bic",
+    # paragraphs
+    "문단": "paragraphs",
+    "단락": "paragraphs",
+    "설명 글": "paragraphs",
+    # datetime
+    "날짜": "datetime",
+    "일시": "datetime",
+    # time
+    "시간": "time",
+    # latitude
+    "위도": "latitude",
+    # longitude
+    "경도": "longitude",
+    # number_between_1_100
+    "숫자": "number_between_1_100",
+    "1과 100 사이 숫자": "number_between_1_100",
+    "1~100 숫자": "number_between_1_100",
+}

--- a/ai-synthor/app/services/korean_processor.py
+++ b/ai-synthor/app/services/korean_processor.py
@@ -1,3 +1,5 @@
+import re
+
 # 지원하는 데이터 타입(필드명) 목록 (한국어 전용, 영문, 언어 중립)
 SUPPORTED_TYPES = {
     # 한국어 전용
@@ -17,59 +19,727 @@ SUPPORTED_TYPES = {
     "paragraphs", "datetime", "time", "latitude", "longitude", "number_between_1_100"
 }
 
+# 조건이 붙을 수 있는 타입 목록
+CONSTRAINT_TYPES = {
+    "password", "phone", "avatar", "state", "country", "datetime", "time", "url",
+    "credit_card_number", "credit_card_type", "paragraphs", "number_between_1_100"
+}
+
+# state, country, credit_card_number, credit_card_type 지원 값 정의 (예시)
+SUPPORTED_STATES = {
+    "California", "New York", "Seoul", "Île-de-France", "Tokyo", "Beijing", "Ontario",
+    "Bavaria (Bayern)", "São Paulo", "Maharashtra", "Istanbul", "England", "Madrid",
+    "New South Wales", "Moscow"
+}
+
+SUPPORTED_COUNTRIES = {
+    "United States", "미국",
+    "China", "중국",
+    "Germany", "독일",
+    "United Kingdom", "영국",
+    "France", "프랑스",
+    "Japan", "일본",
+    "India", "인도",
+    "Russia", "러시아",
+    "South Korea", "대한민국",
+    "Brazil", "브라질",
+    "Canada", "캐나다",
+    "Italy", "이탈리아",
+    "Australia", "호주",
+    "Spain", "스페인",
+    "Turkey", "튀르키예"
+}
+
+SUPPORTED_CARD_TYPES = {
+    "Visa", "Mastercard", "American Express", "Amex", "JCB", "China UnionPay", "Maestro", "Diners Club International"
+}
+
 # 한글 → 영문/한국어 타입 매핑 (예시, 필요시 계속 확장)
 KOR_TO_ENG_FIELD = {
-    # 개인정보
-    "이름": "korean_full_name",
+    # korean_full_name
+    "전체 이름": "korean_full_name",
+    "이름 전체": "korean_full_name",
     "성명": "korean_full_name",
-    "이메일": "email_address",
-    "나이": "number_between_1_100",  # 실제로는 조건 파싱 필요
-    "성별": "gender",  # 필요시 추가
-    "아이디": "username",
-    "비밀번호": "password",
-    "전화번호": "korean_phone",
-    # 주소
+    "풀네임": "korean_full_name",
+    "전성 이름": "korean_full_name",
+    "이름": "korean_full_name",
+    "이름 전체": "korean_full_name",
+    "이름 전부": "korean_full_name",
+    "이름 풀": "korean_full_name",
+    "이름(전체)": "korean_full_name",
+    "이름(풀)": "korean_full_name",
+    "이름 전체명": "korean_full_name",
+    "이름 풀네임": "korean_full_name",
+    # korean_last_name
+    "성": "korean_last_name",
+    "성씨": "korean_last_name",
+    "이씨": "korean_last_name",
+    "김씨": "korean_last_name",
+    "박씨": "korean_last_name",
+    "최씨": "korean_last_name",
+    "이 성": "korean_last_name",
+    "김 성": "korean_last_name",
+    "박 성": "korean_last_name",
+    "최 성": "korean_last_name",
+    "성(이)": "korean_last_name",
+    "성(김)": "korean_last_name",
+    "성(박)": "korean_last_name",
+    "성(최)": "korean_last_name",
+    # korean_first_name
+    "이름(이)": "korean_first_name",
+    "이름(김)": "korean_first_name",
+    "이름(박)": "korean_first_name",
+    "이름(최)": "korean_first_name",
+    "이름만": "korean_first_name",
+    "이름(한글)": "korean_first_name",
+    "이름(영문)": "korean_first_name",
+    # korean_address
     "주소": "korean_address",
+    "전체 주소": "korean_address",
+    "집 주소": "korean_address",
+    "거주지": "korean_address",
+    "거주 주소": "korean_address",
+    "거주지 주소": "korean_address",
+    "거주지 전체": "korean_address",
+    # korean_street_address
+    "도로명 주소": "korean_street_address",
+    "도로 주소": "korean_street_address",
+    "도로명": "korean_street_address",
+    "도로 전체": "korean_street_address",
+    "도로명 전체": "korean_street_address",
     "도로명주소": "korean_street_address",
+    # korean_city
     "도시": "korean_city",
+    "도시 이름": "korean_city",
+    "사는 도시": "korean_city",
+    "거주 도시": "korean_city",
+    "시": "korean_city",
+    "시 이름": "korean_city",
+    "도시 이름(한글)": "korean_city",
+    # korean_state
+    "시도": "korean_state",
     "도": "korean_state",
-    "시": "korean_state",
+    "시/도": "korean_state",
+    "시 도": "korean_state",
+    "도 이름": "korean_state",
+    "시 이름": "korean_state",
+    # korean_country
     "국가": "korean_country",
+    "나라": "korean_country",
+    "거주 국가": "korean_country",
+    "사는 나라": "korean_country",
+    # korean_postal_code
     "우편번호": "korean_postal_code",
-    # 회사 및 상업
-    "회사": "korean_company_name",
+    "우편 코드": "korean_postal_code",
+    "우편 번호": "korean_postal_code",
+    "우편코드": "korean_postal_code",
+    # korean_phone
+    "전화번호": "korean_phone",
+    "휴대폰 번호": "korean_phone",
+    "핸드폰 번호": "korean_phone",
+    "연락처": "korean_phone",
+    "휴대폰": "korean_phone",
+    "핸드폰": "korean_phone",
+    "전화": "korean_phone",
+    # korean_company_name
+    "회사명": "korean_company_name",
+    "회사 이름": "korean_company_name",
+    "근무처": "korean_company_name",
+    "근무 회사": "korean_company_name",
+    # korean_job_title
     "직책": "korean_job_title",
-    "부서": "korean_department_corporate",  # 또는 korean_department_retail
+    "직위": "korean_job_title",
+    "포지션": "korean_job_title",
+    "직무": "korean_job_title",
+    # korean_department_corporate
+    "부서": "korean_department_corporate",
+    "소속": "korean_department_corporate",
+    "소속 부서": "korean_department_corporate",
+    "소속팀": "korean_department_corporate",
+    # korean_product_name
     "제품명": "korean_product_name",
+    "상품명": "korean_product_name",
+    "제품 이름": "korean_product_name",
+    "상품 이름": "korean_product_name",
+    # korean_product_category
     "제품 카테고리": "korean_product_category",
+    "상품 카테고리": "korean_product_category",
+    "제품 종류": "korean_product_category",
+    "상품 종류": "korean_product_category",
+    # korean_catch_phrase
     "캐치프레이즈": "korean_catch_phrase",
+    "슬로건": "korean_catch_phrase",
+    "표어": "korean_catch_phrase",
+    # korean_product_description
     "제품 설명": "korean_product_description",
-    # 기타
+    "상품 설명": "korean_product_description",
+    "제품 소개": "korean_product_description",
+    "상품 소개": "korean_product_description",
+    # korean_language
     "언어": "korean_language",
+    "사용 언어": "korean_language",
+    "쓰는 언어": "korean_language",
+    # korean_color
     "색상": "korean_color",
-    # 언어 중립
+    "컬러": "korean_color",
+    "색": "korean_color",
+    # username
+    "사용자명": "username",
+    "유저명": "username",
+    "계정명": "username",
+    "계정 이름": "username",
+    "유저 이름": "username",
+    # password
+    "비밀번호": "password",
+    "패스워드": "password",
+    "비번": "password",
+    # email_address
+    "이메일": "email_address",
+    "이메일 주소": "email_address",
+    "메일": "email_address",
+    "메일 주소": "email_address",
+    # domain_name
     "도메인": "domain_name",
+    "도메인 이름": "domain_name",
+    # url
     "URL": "url",
-    "MAC": "mac_address",
-    "IPv4": "ip_v4_address",
-    "IPv6": "ip_v6_address",
+    "주소(URL)": "url",
+    "링크": "url",
+    "웹주소": "url",
+    # mac_address
+    "MAC 주소": "mac_address",
+    # ip_v4_address
+    "IPv4 주소": "ip_v4_address",
+    # ip_v6_address
+    "IPv6 주소": "ip_v6_address",
+    # user_agent
     "유저 에이전트": "user_agent",
+    # avatar
     "아바타": "avatar",
+    "프로필 사진": "avatar",
+    "프로필 이미지": "avatar",
+    # app_name
     "앱 이름": "app_name",
+    "어플 이름": "app_name",
+    # app_version
+    "버전": "app_version",
     "앱 버전": "app_version",
+    # device_model
     "기기 모델": "device_model",
-    "기기 제조사": "device_brand",
+    # device_brand
+    "기기 브랜드": "device_brand",
+    # device_os
+    "OS": "device_os",
     "운영체제": "device_os",
+    # credit_card_number
+    "카드번호": "credit_card_number",
     "신용카드 번호": "credit_card_number",
-    "신용카드 종류": "credit_card_type",
-    "상품 가격": "product_price",
+    # credit_card_type
+    "카드 종류": "credit_card_type",
+    "카드 타입": "credit_card_type",
+    "VISA MASTER 종류": "credit_card_type",
+    # currency
     "통화": "currency",
+    "화폐 단위": "currency",
+    # iban
     "IBAN": "iban",
+    "IBAN 코드": "iban",
+    # swift_bic
     "SWIFT": "swift_bic",
+    "SWIFT 코드": "swift_bic",
+    # paragraphs
     "문단": "paragraphs",
+    "단락": "paragraphs",
+    "설명 글": "paragraphs",
+    # datetime
     "날짜": "datetime",
+    "일시": "datetime",
+    # time
     "시간": "time",
+    # latitude
     "위도": "latitude",
+    # longitude
     "경도": "longitude",
-    # 필요시 계속 확장
+    # number_between_1_100
+    "숫자": "number_between_1_100",
+    "1과 100 사이 숫자": "number_between_1_100",
+    "1~100 숫자": "number_between_1_100",
 }
+
+# 한글 → 영문 값 매핑 (state, country, 카드사 등)
+KOR_TO_ENG_VALUE = {
+    # state
+    "서울": "Seoul",
+    "도쿄": "Tokyo",
+    "베이징": "Beijing",
+    "뉴욕": "New York",
+    "파리": "Île-de-France",
+    "상파울루": "São Paulo",
+    "마드리드": "Madrid",
+    "모스크바": "Moscow",
+    "이슬람불": "Istanbul",
+    "바이에른": "Bavaria (Bayern)",
+    "마하라슈트라": "Maharashtra",
+    "온타리오": "Ontario",
+    "뉴사우스웨일스": "New South Wales",
+    "잉글랜드": "England",
+    "캘리포니아": "California",
+    # country
+    "미국": "United States",
+    "중국": "China",
+    "독일": "Germany",
+    "영국": "United Kingdom",
+    "프랑스": "France",
+    "일본": "Japan",
+    "인도": "India",
+    "러시아": "Russia",
+    "대한민국": "South Korea",
+    "한국": "South Korea",
+    "브라질": "Brazil",
+    "캐나다": "Canada",
+    "이탈리아": "Italy",
+    "호주": "Australia",
+    "스페인": "Spain",
+    "튀르키예": "Turkey",
+    # 카드사
+    "비자카드": "Visa",
+    "마스터카드": "Mastercard",
+    "아멕스카드": "American Express",
+    "JCB카드": "JCB",
+    "유니온페이": "China UnionPay",
+    "마에스트로": "Maestro",
+    "다이너스클럽": "Diners Club International",
+    "아메리칸 익스프레스": "American Express",
+    "아멕스": "Amex",
+}
+
+def parse_korean_text_to_json(text: str) -> dict:
+    count_match = re.search(r'(\d+)\s*(명|개|건|줄|users|rows|entries|개체|개씩|개만)|at least (\d+)', text, re.IGNORECASE)
+    if count_match:
+        count = int(next(filter(None, count_match.groups())))
+    else:
+        count = 1
+
+    fields = []
+    unsupported_fields = []
+    used_fields = set()
+
+    # 1. 한글 키워드 매핑
+    for kor, eng in KOR_TO_ENG_FIELD.items():
+        if kor in text and eng not in used_fields:
+            used_fields.add(eng)
+            constraints = None
+            # 조건이 붙을 수 있는 타입에만 조건 파싱 적용
+            if eng in CONSTRAINT_TYPES:
+                # number_between_1_100
+                if eng == "number_between_1_100":
+                    min_match = re.search(r'(\d+)\s*이상|at least (\d+)', text, re.IGNORECASE)
+                    max_match = re.search(r'(\d+)\s*이하|under (\d+)', text, re.IGNORECASE)
+                    decimals_match = re.search(r'소수점\s*(\d+)자리|decimals?\s*(\d+)', text, re.IGNORECASE)
+                    cdict = {}
+                    if min_match:
+                        min_val = next(filter(None, min_match.groups()))
+                        cdict["min"] = int(min_val)
+                    if max_match:
+                        max_val = next(filter(None, max_match.groups()))
+                        cdict["max"] = int(max_val)
+                    if decimals_match:
+                        dec_val = next(filter(None, decimals_match.groups()))
+                        cdict["decimals"] = int(dec_val)
+                    if cdict:
+                        constraints = cdict
+                # password
+                elif eng == "password":
+                    minlen = re.search(r'(\d+)자 이상|minimum length:?\s*(\d+)', text, re.IGNORECASE)
+                    upper = re.search(r'대문자\s*(\d+)개|upper:?\s*(\d+)', text, re.IGNORECASE)
+                    lower = re.search(r'소문자\s*(\d+)개|lower:?\s*(\d+)', text, re.IGNORECASE)
+                    numbers = re.search(r'숫자\s*(\d+)개|numbers?:?\s*(\d+)', text, re.IGNORECASE)
+                    symbols = re.search(r'특수문자\s*(\d+)개|symbols?:?\s*(\d+)', text, re.IGNORECASE)
+                    cdict = {}
+                    if minlen:
+                        minlen_val = next(filter(None, minlen.groups()))
+                        cdict["min_length"] = int(minlen_val)
+                    if upper:
+                        upper_val = next(filter(None, upper.groups()))
+                        cdict["upper"] = int(upper_val)
+                    if lower:
+                        lower_val = next(filter(None, lower.groups()))
+                        cdict["lower"] = int(lower_val)
+                    if numbers:
+                        numbers_val = next(filter(None, numbers.groups()))
+                        cdict["numbers"] = int(numbers_val)
+                    if symbols:
+                        symbols_val = next(filter(None, symbols.groups()))
+                        cdict["symbols"] = int(symbols_val)
+                    if cdict:
+                        constraints = cdict
+                # phone
+                elif eng == "phone":
+                    phone_format = None
+                    for fmt in ["###-####-####", "(###) ###-####", "### ### ####", "+# ### ### ####", "+# (###) ###-####", "+#-###-###-####", "#-(###) ###-####", "##########"]:
+                        if fmt.replace("#", "") in text:
+                            phone_format = fmt
+                    if phone_format:
+                        constraints = {"format": phone_format}
+                # avatar
+                elif eng == "avatar":
+                    avatar_size = re.search(r'(\d+)x(\d+)|size:?\s*(\d+)\s*[xX*]\s*(\d+)', text, re.IGNORECASE)
+                    avatar_format = None
+                    for fmt in ["png", "bmp", "jpg"]:
+                        if fmt in text.lower():
+                            avatar_format = fmt
+                    cdict = {}
+                    if avatar_size:
+                        size_groups = avatar_size.groups()
+                        w = next(filter(None, size_groups[0:3]))
+                        h = next(filter(None, size_groups[1:4]))
+                        cdict["size"] = f"{w}x{h}"
+                    if avatar_format:
+                        cdict["format"] = avatar_format
+                    if cdict:
+                        constraints = cdict
+                # state
+                elif eng == "state":
+                    state_value = re.search(r'([가-힣A-Za-z \-\(\)]+)만|only ([A-Za-z \-\(\)]+)', text)
+                    val = None
+                    if state_value:
+                        val = next(filter(None, state_value.groups())).strip()
+                    if val:
+                        val_eng = KOR_TO_ENG_VALUE.get(val, val)
+                        if val_eng in SUPPORTED_STATES:
+                            constraints = {"value": val_eng}
+                        else:
+                            return {"error": f"지원하지 않는 state 값입니다: {val}"}
+                # country
+                elif eng == "country":
+                    country_value = re.search(r'([가-힣A-Za-z \-\(\)]+)만|only ([A-Za-z \-\(\)]+)', text)
+                    val = None
+                    if country_value:
+                        val = next(filter(None, country_value.groups())).strip()
+                    if val:
+                        val_eng = KOR_TO_ENG_VALUE.get(val, val)
+                        if val_eng in SUPPORTED_COUNTRIES:
+                            constraints = {"value": val_eng}
+                        else:
+                            return {"error": f"지원하지 않는 country 값입니다: {val}"}
+                # datetime
+                elif eng == "datetime":
+                    dt_from = re.search(r'(\d{4}-\d{2}-\d{2})부터|from (\d{4}-\d{2}-\d{2})', text, re.IGNORECASE)
+                    dt_to = re.search(r'부터\s*(\d{4}-\d{2}-\d{2})까지|to (\d{4}-\d{2}-\d{2})', text, re.IGNORECASE)
+                    dt_format = re.search(r'(yyyy-mm-dd|m/d/yyyy|d/m/yyyy)', text, re.IGNORECASE)
+                    cdict = {}
+                    if dt_from:
+                        from_val = next(filter(None, dt_from.groups()))
+                        cdict["from"] = from_val
+                    if dt_to:
+                        to_val = next(filter(None, dt_to.groups()))
+                        cdict["to"] = to_val
+                    if dt_format:
+                        cdict["format"] = dt_format.group(1)
+                    if cdict:
+                        constraints = cdict
+                # time
+                elif eng == "time":
+                    time_from = re.search(r'(오전|오후)?\s*(\d{1,2})시부터|from (\d{1,2})(am|pm)?', text, re.IGNORECASE)
+                    time_to = re.search(r'부터\s*(오전|오후)?\s*(\d{1,2})시까지|to (\d{1,2})(am|pm)?', text, re.IGNORECASE)
+                    time_format = re.search(r'(12시간제|24시간제|12 ?hour|24 ?hour)', text, re.IGNORECASE)
+                    cdict = {}
+                    if time_from:
+                        if time_from.group(1):
+                            cdict["from"] = f"{time_from.group(1)}{time_from.group(2)}"
+                        elif time_from.group(3):
+                            cdict["from"] = f"{time_from.group(2)}{time_from.group(3)}"
+                    if time_to:
+                        if time_to.group(1):
+                            cdict["to"] = f"{time_to.group(1)}{time_to.group(2)}"
+                        elif time_to.group(3):
+                            cdict["to"] = f"{time_to.group(2)}{time_to.group(3)}"
+                    if time_format:
+                        cdict["format"] = time_format.group(1)
+                    if cdict:
+                        constraints = cdict
+                # url
+                elif eng == "url":
+                    url_protocol = "protocol" in text.lower() or "프로토콜" in text
+                    url_host = "host" in text.lower() or "호스트" in text
+                    url_path = "path" in text.lower() or "경로" in text
+                    url_query = "query" in text.lower() or "쿼리" in text
+                    cdict = {}
+                    if url_protocol:
+                        cdict["protocol"] = True
+                    if url_host:
+                        cdict["host"] = True
+                    if url_path:
+                        cdict["path"] = True
+                    if url_query:
+                        cdict["query"] = True
+                    if cdict:
+                        constraints = cdict
+                # credit_card_number
+                elif eng == "credit_card_number":
+                    card_type = None
+                    for t in SUPPORTED_CARD_TYPES:
+                        kor_t = [k for k, v in KOR_TO_ENG_VALUE.items() if v == t]
+                        if t.lower() in text.lower() or any(k in text for k in kor_t):
+                            card_type = t
+                    if card_type:
+                        constraints = {"type": card_type}
+                    else:
+                        return {"error": "지원하지 않는 카드사입니다."}
+                # credit_card_type
+                elif eng == "credit_card_type":
+                    cct_value = None
+                    for t in SUPPORTED_CARD_TYPES:
+                        kor_t = [k for k, v in KOR_TO_ENG_VALUE.items() if v == t]
+                        if t.lower() in text.lower() or any(k in text for k in kor_t):
+                            cct_value = t
+                    if cct_value:
+                        constraints = {"value": cct_value}
+                    else:
+                        return {"error": "지원하지 않는 카드사입니다."}
+                # paragraphs
+                elif eng == "paragraphs":
+                    para_min = re.search(r'최소\s*(\d+)문단|at least (\d+) paragraphs?', text, re.IGNORECASE)
+                    para_max = re.search(r'최대\s*(\d+)문단|no more than (\d+) paragraphs?', text, re.IGNORECASE)
+                    cdict = {}
+                    if para_min:
+                        min_val = next(filter(None, para_min.groups()))
+                        cdict["min"] = int(min_val)
+                    if para_max:
+                        max_val = next(filter(None, para_max.groups()))
+                        cdict["max"] = int(max_val)
+                    if cdict:
+                        constraints = cdict
+            # 나머지 타입은 constraints 없이 제공
+            if eng not in SUPPORTED_TYPES:
+                unsupported_fields.append(eng)
+            else:
+                if eng == "number_between_1_100":
+                    field_type = "number"
+                elif eng.startswith("korean_") and "phone" in eng:
+                    field_type = "string"
+                else:
+                    field_type = "string"
+                field_obj = {"name": eng, "type": field_type}
+                if constraints is not None:
+                    field_obj["constraints"] = constraints
+                fields.append(field_obj)
+
+    # 2. 영문 타입명 직접 매칭
+    for eng in SUPPORTED_TYPES:
+        # "로", "만" 등 조사 제거 후 타입명만 추출
+        if (f"{eng}로" in text or f"{eng}만" in text or eng in text) and eng not in used_fields:
+            used_fields.add(eng)
+            constraints = None
+            # 조건이 붙을 수 있는 타입에만 constraints 파싱 적용
+            if eng in CONSTRAINT_TYPES:
+                # number_between_1_100
+                if eng == "number_between_1_100":
+                    min_match = re.search(r'(\d+)\s*이상', text)
+                    max_match = re.search(r'(\d+)\s*이하', text)
+                    decimals_match = re.search(r'소수점\s*(\d+)자리', text)
+                    cdict = {}
+                    if min_match:
+                        cdict["min"] = int(min_match.group(1))
+                    if max_match:
+                        cdict["max"] = int(max_match.group(1))
+                    if decimals_match:
+                        cdict["decimals"] = int(decimals_match.group(1))
+                    if cdict:
+                        constraints = cdict
+                # password
+                elif eng == "password":
+                    minlen = re.search(r'(\d+)자 이상', text)
+                    upper = re.search(r'대문자\s*(\d+)개', text)
+                    lower = re.search(r'소문자\s*(\d+)개', text)
+                    numbers = re.search(r'숫자\s*(\d+)개', text)
+                    symbols = re.search(r'특수문자\s*(\d+)개', text)
+                    cdict = {}
+                    if minlen:
+                        cdict["min_length"] = int(minlen.group(1))
+                    if upper:
+                        cdict["upper"] = int(upper.group(1))
+                    if lower:
+                        cdict["lower"] = int(lower.group(1))
+                    if numbers:
+                        cdict["numbers"] = int(numbers.group(1))
+                    if symbols:
+                        cdict["symbols"] = int(symbols.group(1))
+                    if cdict:
+                        constraints = cdict
+                # phone
+                elif eng == "phone":
+                    phone_format = None
+                    for fmt in ["###-####-####", "(###) ###-####", "### ### ####", "+# ### ### ####", "+# (###) ###-####", "+#-###-###-####", "#-(###) ###-####", "##########"]:
+                        if fmt.replace("#", "") in text:
+                            phone_format = fmt
+                    if phone_format:
+                        constraints = {"format": phone_format}
+                # avatar
+                elif eng == "avatar":
+                    avatar_size = re.search(r'(\d+)x(\d+)', text)
+                    avatar_format = None
+                    for fmt in ["png", "bmp", "jpg"]:
+                        if fmt in text:
+                            avatar_format = fmt
+                    cdict = {}
+                    if avatar_size:
+                        cdict["size"] = f"{avatar_size.group(1)}x{avatar_size.group(2)}"
+                    if avatar_format:
+                        cdict["format"] = avatar_format
+                    if cdict:
+                        constraints = cdict
+                # state
+                elif eng == "state":
+                    state_value = re.search(r'([가-힣A-Za-z ]+)만', text)
+                    if state_value:
+                        val = state_value.group(1).strip()
+                        val_eng = KOR_TO_ENG_VALUE.get(val, val)
+                        if val_eng in SUPPORTED_STATES:
+                            constraints = {"value": val_eng}
+                        else:
+                            return {"error": f"지원하지 않는 state 값입니다: {val}"}
+                # country
+                elif eng == "country":
+                    country_value = re.search(r'([가-힣A-Za-z ]+)만', text)
+                    if country_value:
+                        val = country_value.group(1).strip()
+                        val_eng = KOR_TO_ENG_VALUE.get(val, val)
+                        if val_eng in SUPPORTED_COUNTRIES:
+                            constraints = {"value": val_eng}
+                        else:
+                            return {"error": f"지원하지 않는 country 값입니다: {val}"}
+                # datetime
+                elif eng == "datetime":
+                    dt_from = re.search(r'(\d{4}-\d{2}-\d{2})부터', text)
+                    dt_to = re.search(r'부터\s*(\d{4}-\d{2}-\d{2})까지', text)
+                    dt_format = re.search(r'(yyyy-mm-dd|m/d/yyyy|d/m/yyyy)', text)
+                    cdict = {}
+                    if dt_from:
+                        cdict["from"] = dt_from.group(1)
+                    if dt_to:
+                        cdict["to"] = dt_to.group(1)
+                    if dt_format:
+                        cdict["format"] = dt_format.group(1)
+                    if cdict:
+                        constraints = cdict
+                # time
+                elif eng == "time":
+                    time_from = re.search(r'(오전|오후)?\s*(\d{1,2})시부터', text)
+                    time_to = re.search(r'부터\s*(오전|오후)?\s*(\d{1,2})시까지', text)
+                    time_format = re.search(r'(12시간제|24시간제)', text)
+                    cdict = {}
+                    if time_from:
+                        cdict["from"] = f"{time_from.group(1) or ''}{time_from.group(2)}"
+                    if time_to:
+                        cdict["to"] = f"{time_to.group(1) or ''}{time_to.group(2)}"
+                    if time_format:
+                        cdict["format"] = time_format.group(1)
+                    if cdict:
+                        constraints = cdict
+                # url
+                elif eng == "url":
+                    url_protocol = "protocol" in text or "프로토콜" in text
+                    url_host = "host" in text or "호스트" in text
+                    url_path = "path" in text or "경로" in text
+                    url_query = "query" in text or "쿼리" in text
+                    cdict = {}
+                    if url_protocol:
+                        cdict["protocol"] = True
+                    if url_host:
+                        cdict["host"] = True
+                    if url_path:
+                        cdict["path"] = True
+                    if url_query:
+                        cdict["query"] = True
+                    if cdict:
+                        constraints = cdict
+                # credit_card_number
+                elif eng == "credit_card_number":
+                    card_type = None
+                    for t in SUPPORTED_CARD_TYPES:
+                        kor_t = [k for k, v in KOR_TO_ENG_VALUE.items() if v == t]
+                        if t.lower() in text.lower() or any(k in text for k in kor_t):
+                            card_type = t
+                    if card_type:
+                        constraints = {"type": card_type}
+                    else:
+                        return {"error": "지원하지 않는 카드사입니다."}
+                # credit_card_type
+                elif eng == "credit_card_type":
+                    cct_value = None
+                    for t in SUPPORTED_CARD_TYPES:
+                        kor_t = [k for k, v in KOR_TO_ENG_VALUE.items() if v == t]
+                        if t.lower() in text.lower() or any(k in text for k in kor_t):
+                            cct_value = t
+                    if cct_value:
+                        constraints = {"value": cct_value}
+                    else:
+                        return {"error": "지원하지 않는 카드사입니다."}
+                # paragraphs
+                elif eng == "paragraphs":
+                    para_min = re.search(r'최소\s*(\d+)문단', text)
+                    para_max = re.search(r'최대\s*(\d+)문단', text)
+                    cdict = {}
+                    if para_min:
+                        cdict["min"] = int(para_min.group(1))
+                    if para_max:
+                        cdict["max"] = int(para_max.group(1))
+                    if cdict:
+                        constraints = cdict
+            if eng not in SUPPORTED_TYPES:
+                unsupported_fields.append(eng)
+            else:
+                if eng == "number_between_1_100":
+                    field_type = "number"
+                elif eng.startswith("korean_") and "phone" in eng:
+                    field_type = "string"
+                else:
+                    field_type = "string"
+                field_obj = {"name": eng, "type": field_type}
+                if constraints is not None:
+                    field_obj["constraints"] = constraints
+                fields.append(field_obj)
+
+    if unsupported_fields:
+        return {
+            "error": f"지원하지 않는 데이터 타입입니다: {', '.join(unsupported_fields)}",
+            "unsupported_fields": unsupported_fields
+        }
+
+    if not fields:
+        return {
+            "error": "추출된 데이터 필드가 없습니다. 입력을 확인해 주세요."
+        }
+
+    return {
+        "count": count,
+        "fields": fields
+    }
+
+# 혼합 입력 테스트 케이스 추가
+if __name__ == "__main__":
+    test_cases = [
+        # 혼합 입력 예시
+        "10 users, 이메일은 gmail만, 나이는 under 40",
+        "Generate 5개 email_address, 이름은 한국어로",
+        "최소 2문단, no more than 5 paragraphs",
+        "50x50 png avatar, size: 100x100, format: jpg 2개",
+        # 기존 테스트 케이스
+        "언어 5개",
+        "서울만 state로 5개",
+        "파리만 state로 3개",
+        "한국만 country로 2개",
+        "브라질만 country로 2개",
+        "비자카드만 credit_card_number로 2개",
+        "아멕스카드만 credit_card_type로 2개",
+        "없는나라 country로 1개",
+        "없는카드 credit_card_type로 1개",
+        "비밀번호 8자 이상, 대문자 1개, blank 0% 3개",
+        "50x50 png avatar 2개",
+        "10 이상 50 이하 소수점 2자리 number_between_1_100 4개"
+    ]
+    for text in test_cases:
+        print(f"입력: {text}")
+        print(parse_korean_text_to_json(text))
+        print("-" * 40)


### PR DESCRIPTION
## 🚀 Topgun PR 요약
- 사용자가 입력한 한국어 자연어 문장에서 필드, 타입, 조건, 개수 정보 추출
- SUPPORTED_TYPES 및 KOR_TO_ENG_FIELD 매핑 활용
- JSON(dict) 구조로 변환하는 파싱 함수 `parse_korean_text_to_json` 구현

## ✅ 작업 내용
- [ ] 자연어에서 개수(count) 추출
- [ ] 필드명-타입명 매핑 및 타입 유효성 검사
- [ ] 조건(예: 미만, gmail만, 남성 등) 추출 → constraints 구성
- [ ] 조건이 없을 경우 `None`으로 처리
- [ ] 타입 누락, 필드 없음 등 에러 메시지 반환
- [ ] JSON 형식으로 파싱 결과 반환

## 🔗 관련 이슈
- Close #5

## 🧪 테스트 내용
- [ ] `"50x50 png avatar 2개"` → {'count': 2, 'fields': [{'name': 'avatar', 'type': 'string', 'constraints': {'size': '50x50', 'format': 'png'}}]}
- [ ] 조건 누락 시 constraints 생략 확인
- [ ] 지원되지 않는 타입 입력 시 에러 메시지 반환 확인

## 📝 기타 참고 사항
- korean_processor.py 내부에 함수로 정의됨
- 추후 영어/영문 자연어 파싱에도 확장 가능하도록 구조 설계됨