### PR TITLE
[FE] 비밀번호 제약 조건 파서 개선 (#11)

### DIFF
--- a/ai-synthor/app/services/cli.py
+++ b/ai-synthor/app/services/cli.py
@@ -67,6 +67,7 @@ if __name__ == "__main__":
         "년월일 포맷",
         "year-month-day format",
         "주문 날짜(order_date)는 2025-02-01 ~ 2025-11-31 사이여야 해.",
+        "비밀번호는 최소 10자 이상이고 숫자와 특수 문자가 포함되어야 해",
     ]
     for t in test_cases:
         print("입력:", t)

--- a/ai-synthor/app/services/constraint_parser.py
+++ b/ai-synthor/app/services/constraint_parser.py
@@ -85,6 +85,9 @@ class Parser:
 
         # 4) 최종 JSON 조립 (원 코드와 완전 동일 포맷)
         if field in CONSTRAINT_TYPES:
-            return {"type": field, "constraints": constraints, "nullablePercent": nullable}
+            # 타입 이름을 대문자로 시작하도록 변환
+            type_name = field.replace("_", " ").title().replace(" ", "")
+            return {"type": type_name, "constraints": constraints, "nullablePercent": nullable}
         else:
-            return {"type": field, "constraints": {}, "nullablePercent": nullable}
+            type_name = field.replace("_", " ").title().replace(" ", "")
+            return {"type": type_name, "constraints": {}, "nullablePercent": nullable}

--- a/ai-synthor/app/services/constraints/password.py
+++ b/ai-synthor/app/services/constraints/password.py
@@ -8,7 +8,20 @@ class PasswordExtractor(ConstraintExtractor):
         c = {}
 
         def pick(m):
-            return int(next(filter(None, m.groups()))) if m else None
+            if not m:
+                return None
+            # 포함 패턴의 경우 그룹이 비어있으면 기본값 1 반환
+            groups = list(filter(None, m.groups()))
+            if groups:
+                # 숫자인지 확인 후 변환
+                for group in groups:
+                    if group.isdigit():
+                        return int(group)
+                # 숫자가 없으면 포함 패턴으로 간주하고 기본값 1 반환
+                return 1
+            else:
+                # 포함 패턴으로 매치된 경우 기본값 1 반환
+                return 1
 
         #최소 길이 (숫자 명시형만, ≥N)
         m_min = re.search(
@@ -54,7 +67,8 @@ class PasswordExtractor(ConstraintExtractor):
             r'numbers?[:\s]*:?[\s]*(\d+)|'
             r'digits?[:\s]*:?[\s]*(\d+)|'
             r'numerals?[:\s]*:?[\s]*(\d+)|'                         #numeral: 2
-            r'(?:at\s*least|no\s*less\s*than)\s*(\d+)\s*(?:digits?|numbers?|numerals?)',
+            r'(?:at\s*least|no\s*less\s*than)\s*(\d+)\s*(?:digits?|numbers?|numerals?)|'
+            r'(숫자.*?포함.*?(?:되어야|해야)|포함.*?숫자)',              # 숫자 포함되어야 해
             text, re.I
         )
 
@@ -67,7 +81,8 @@ class PasswordExtractor(ConstraintExtractor):
             r'symbols?[:\s]*:?[\s]*(\d+)|'
             r'punctuation[:\s]*:?[\s]*(\d+)|'
             r'non[- ]?alphanumeric[:\s]*:?[\s]*(\d+)|'
-            r'(?:at\s*least|no\s*less\s*than)\s*(\d+)\s*(?:symbols?|punctuation|special\s*(?:chars?|characters?))',
+            r'(?:at\s*least|no\s*less\s*than)\s*(\d+)\s*(?:symbols?|punctuation|special\s*(?:chars?|characters?))|'
+            r'((?:특수.*?문자|특문|기호).*?포함.*?(?:되어야|해야)|포함.*?(?:특수.*?문자|특문|기호))',  # 특수 문자 포함되어야 해
             text, re.I
         )
 


### PR DESCRIPTION
## 🚀 Topgun PR 요약
- 비밀번호 파서에서 숫자 및 특수 문자 감지 기능 추가
- CLI hooks를 통해 테스트 실행 로직 연동

## ✅ 작업 내용
- [ ] 비밀번호 제약 조건(숫자·특수 문자) 감지 로직 추가
- [ ] constraint_parser.py 개선
- [ ] CLI 기반 테스트 코드 실행 로직 추가

## 🔗 관련 이슈
- Close #11

## 🧪 테스트 내용
- [ ] "Password@123" → 숫자 포함 여부, 특수 문자 포함 여부를 JSON으로 반환
